### PR TITLE
Detect 見れる as special invalid case.

### DIFF
--- a/src/no-dropping-the-ra.js
+++ b/src/no-dropping-the-ra.js
@@ -16,8 +16,10 @@ function isRaWord(token) {
     return token.pos == "動詞" && token.pos_detail_1 == "接尾" && token.basic_form == "れる";
 }
 
-function isKoreru(token) {
-    return token.pos == "動詞" && token.basic_form == "来れる";
+function isSpecialCases(token) {
+    // Due to kuromoji.js's behavior, some dropping-ra words will be tokenized as one.
+    // See also https://github.com/takuyaa/kuromoji.js/issues/28
+    return token.pos == "動詞" && (token.basic_form == "来れる" || token.basic_form == "見れる");
 }
 
 module.exports = function (context) {
@@ -31,7 +33,7 @@ module.exports = function (context) {
             const text = getSource(node);
             return tokenize(text).then(tokens => {
                 tokens.forEach(token => {
-                    if (isKoreru(token)) {
+                    if (isSpecialCases(token)) {
                         report(
                             node,
                             new RuleError("ら抜き言葉を使用しています。", {

--- a/test/no-double-joshi-test.js
+++ b/test/no-double-joshi-test.js
@@ -32,6 +32,16 @@ tester.run("no-dropping-the-ra", rule, {
             ]
         },
         {
+            text: "この距離からでも見れる。",
+            errors: [
+                {
+                    message: "ら抜き言葉を使用しています。",
+                    line: 1,
+                    column: 10
+                }
+            ]
+        },
+        {
             text: "来れる",
             errors: [
                 {


### PR DESCRIPTION
As same as #2, "見れる" will be also tokenized as one.
According to kuromoji.js, this behaviour depends on the dict.
https://github.com/takuyaa/kuromoji.js/issues/28

I don't think we need to cover all of these cases,
But "見れる" is commonly used wrong word, so I recommend to add it too.
